### PR TITLE
Missing public resource and trash control methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,47 @@ const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
 })();
 ```
 
+### Trash Actions
+
+#### delete(token, [path])
+
+Empty Trash completely or remove a specific resource from Trash. See [details](https://yandex.com/dev/disk-api/doc/en/reference/trash-delete).
+
+```javascript
+import { trash } from 'ya-disk';
+
+const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
+
+// Empty whole Trash
+trash.delete(API_TOKEN);
+
+// Remove specific resource from Trash
+trash.delete(API_TOKEN, '/foo/photo.png');
+```
+
+#### restore(token, path, [name], [overwrite=false])
+
+Restore a resource from Trash. See [details](https://yandex.com/dev/disk-api/doc/en/reference/trash-restore).
+
+```javascript
+import { trash } from 'ya-disk';
+
+const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
+
+(async () => {
+  try {
+    await trash.restore(
+      API_TOKEN,
+      '/foo/photo.png',
+      'photo-restored.png',
+      true
+    );
+  } catch (error) {
+    console.error(error);
+  }
+})();
+```
+
 ## Examples
 
 You may find examples of the real usage in the `examples` folder. You should obtain the API key first. Now you can run any example with API key passed as env-variable:

--- a/README.md
+++ b/README.md
@@ -361,6 +361,47 @@ const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
 resources.remove(API_TOKEN, 'disk:/fileOrFolderName', false);
 ```
 
+#### publish(token, path)
+
+Publish file or folder and get public access link metadata. See [details](https://yandex.com/dev/disk-api/doc/en/reference/publish).
+
+```javascript
+import { resources } from 'ya-disk';
+
+const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
+
+(async () => {
+  try {
+    const link = await resources.publish(API_TOKEN, 'disk:/fileOrFolderName');
+    console.log(link.href);
+  } catch (error) {
+    console.error(error);
+  }
+})();
+```
+
+#### unpublish(token, path)
+
+Unpublish file or folder and revoke public access. See [details](https://yandex.com/dev/disk-api/doc/en/reference/publish#unpublish-q).
+
+```javascript
+import { resources } from 'ya-disk';
+
+const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
+
+(async () => {
+  try {
+    const link = await resources.unpublish(
+      API_TOKEN,
+      'disk:/fileOrFolderName'
+    );
+    console.log(link.href);
+  } catch (error) {
+    console.error(error);
+  }
+})();
+```
+
 ## Examples
 
 You may find examples of the real usage in the `examples` folder. You should obtain the API key first. Now you can run any example with API key passed as env-variable:

--- a/README.md
+++ b/README.md
@@ -391,11 +391,96 @@ const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
 
 (async () => {
   try {
-    const link = await resources.unpublish(
-      API_TOKEN,
-      'disk:/fileOrFolderName'
-    );
+    const link = await resources.unpublish(API_TOKEN, 'disk:/fileOrFolderName');
     console.log(link.href);
+  } catch (error) {
+    console.error(error);
+  }
+})();
+```
+
+### Public Resources
+
+#### publicResources.get(token, public_key, [options={}])
+
+Get meta-information for a public resource by its key or URL. See [details](https://yandex.com/dev/disk-api/doc/en/reference/public).
+
+```javascript
+import { publicResources } from 'ya-disk';
+
+const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
+
+(async () => {
+  try {
+    const resource = await publicResources.get(
+      API_TOKEN,
+      'https://disk.yandex.com/d/abc123'
+    );
+    console.log(resource.name);
+  } catch (error) {
+    console.error(error);
+  }
+})();
+```
+
+#### publicResources.download(token, public_key, [path])
+
+Get a download link for a public resource. See [details](https://yandex.com/dev/disk-api/doc/en/reference/public).
+
+```javascript
+import { publicResources } from 'ya-disk';
+
+const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
+
+(async () => {
+  try {
+    const { href } = await publicResources.download(
+      API_TOKEN,
+      'https://disk.yandex.com/d/abc123'
+    );
+    console.log(href);
+  } catch (error) {
+    console.error(error);
+  }
+})();
+```
+
+#### publicResources.saveToDisk(token, public_key, [path], [name])
+
+Save a public resource to the user's Downloads folder. See [details](https://yandex.com/dev/disk-api/doc/en/reference/public).
+
+```javascript
+import { publicResources } from 'ya-disk';
+
+const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
+
+(async () => {
+  try {
+    await publicResources.saveToDisk(
+      API_TOKEN,
+      'https://disk.yandex.com/d/abc123',
+      null,
+      'my-copy.png'
+    );
+  } catch (error) {
+    console.error(error);
+  }
+})();
+```
+
+#### publicResources.list(token, [options])
+
+Get a list of the user's published resources. See [details](https://yandex.com/dev/disk-api/doc/en/reference/recent-public).
+
+```javascript
+import { publicResources } from 'ya-disk';
+
+const API_TOKEN = '1982jhk12h31iad7a(*&kjas';
+
+(async () => {
+  try {
+    const { items } = await publicResources.list(API_TOKEN, { type: 'file' });
+    items.forEach((item) => console.log(item.name));
   } catch (error) {
     console.error(error);
   }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
   operations: require('./lib/operations'),
   publicResources: require('./lib/publicResource'),
   recent: require('./lib/recent'),
+  trash: require('./lib/trash'),
   upload: require('./lib/upload'),
   resources: require('./lib/resources')
 };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
   list: require('./lib/list'),
   meta: require('./lib/meta'),
   operations: require('./lib/operations'),
+  publicResources: require('./lib/publicResource'),
   recent: require('./lib/recent'),
   upload: require('./lib/upload'),
   resources: require('./lib/resources')

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -73,6 +73,20 @@ const API_PUBLISH_URL = `${API_RESOURCES_URL}/publish`;
 const API_UNPUBLISH_URL = `${API_RESOURCES_URL}/unpublish`;
 
 /**
+ * URL for requesting public resource meta-information
+ * @see https://yandex.com/dev/disk-api/doc/en/reference/public
+ * @type {string}
+ */
+const API_PUBLIC_RESOURCES_URL = `${API_DISK_URL}/public/resources`;
+
+/**
+ * URL for requesting download link for public resource
+ * @see https://yandex.com/dev/disk-api/doc/en/reference/public
+ * @type {string}
+ */
+const API_PUBLIC_DOWNLOAD_URL = `${API_PUBLIC_RESOURCES_URL}/download`;
+
+/**
  * URL for saving published resource to Download folder
  * @see https://tech.yandex.com/disk/api/reference/public-docpage/#save
  * @type {string}
@@ -117,6 +131,8 @@ module.exports = {
   API_MOVE_URL,
   API_PUBLISH_URL,
   API_UNPUBLISH_URL,
+  API_PUBLIC_RESOURCES_URL,
+  API_PUBLIC_DOWNLOAD_URL,
   API_SAVE_TO_DISK_URL,
   API_PUBLIC_URL,
   API_TRASH_URL,

--- a/lib/publicResource.js
+++ b/lib/publicResource.js
@@ -1,0 +1,107 @@
+/**
+ * Working with public resources
+ * @module ya-disk/publicResource
+ */
+const request = require('./request');
+
+const {
+  API_PUBLIC_URL,
+  API_PUBLIC_RESOURCES_URL,
+  API_PUBLIC_DOWNLOAD_URL,
+  API_SAVE_TO_DISK_URL
+} = require('./constants');
+
+/**
+ * @typedef {import('./meta').Resource} Resource
+ * @typedef {import('./download').Link} Link
+ *
+ * @typedef {object} PublicResourceGetOptions
+ * @prop {string} [path] Relative path to a resource in the public folder
+ * @prop {string} [sort] Sort field for folder items: name, path, created, modified, size
+ * @prop {number} [limit] Maximum number of described nested resources
+ * @prop {number} [offset] Number of resources to skip from the top of the list
+ * @prop {string} [preview_size] Preview size for supported image resources
+ * @prop {boolean} [preview_crop] Crop preview image if true
+ *
+ * @typedef {object} PublicResourceListOptions
+ * @prop {number} [limit] Maximum number of published resources in response
+ * @prop {number} [offset] Number of resources to skip from the top of the list
+ * @prop {('file'|'dir')} [type] Resource type filter
+ * @prop {string} [fields] Comma-separated list of fields to include in response
+ * @prop {string} [preview_size] Preview size for supported image resources
+ */
+
+/**
+ * Request meta-information for a public resource
+ * @see https://yandex.com/dev/disk-api/doc/en/reference/public
+ * @param {string} token OAuth token
+ * @param {string} public_key Public resource key or URL
+ * @param {PublicResourceGetOptions} [options={}] Additional query options
+ * @returns {Promise<Resource, Error>} Promise resolved with resource metadata
+ */
+const get = async (token, public_key, options = {}) =>
+  (
+    await request.get({
+      url: API_PUBLIC_RESOURCES_URL,
+      token,
+      query: { public_key, ...options }
+    })
+  ).data;
+
+/**
+ * Request download link for a public resource
+ * @see https://yandex.com/dev/disk-api/doc/en/reference/public
+ * @param {string} token OAuth token
+ * @param {string} public_key Public resource key or URL
+ * @param {string} [path] Relative path in public folder
+ * @returns {Promise<Link, Error>} Promise resolved with download link
+ */
+const download = async (token, public_key, path) =>
+  (
+    await request.get({
+      url: API_PUBLIC_DOWNLOAD_URL,
+      token,
+      query: { public_key, path }
+    })
+  ).data;
+
+/**
+ * Save a public resource to the Downloads folder
+ * @see https://yandex.com/dev/disk-api/doc/en/reference/public
+ * @param {string} token OAuth token
+ * @param {string} public_key Public resource key or URL
+ * @param {string} [path] Relative path in public folder
+ * @param {string} [name] New name for saved resource
+ * @returns {Promise<Link, Error>} Promise resolved with result link
+ */
+const saveToDisk = async (token, public_key, path, name) =>
+  (
+    await request.post({
+      url: API_SAVE_TO_DISK_URL,
+      token,
+      query: { public_key, path, name }
+    })
+  ).data;
+
+/**
+ * Get list of user published resources
+ * @see https://yandex.com/dev/disk-api/doc/en/reference/recent-public
+ * @param {string} token OAuth token
+ * @param {PublicResourceListOptions} [options] Additional query parameters
+ * @returns {Promise<{items: Resource[]}, Error>} Promise resolved with published resources list
+ */
+const list = async (token, options) =>
+  (
+    await request.get({
+      url: API_PUBLIC_URL,
+      token,
+      query: options
+    })
+  ).data;
+
+module.exports = {
+  get,
+  download,
+  saveToDisk,
+  list
+};

--- a/lib/request.js
+++ b/lib/request.js
@@ -12,6 +12,20 @@ const defaultRequestParams = {
   data: null
 };
 
+const cleanQuery = (query) => {
+  if (!query) {
+    return null;
+  }
+
+  const cleaned = Object.fromEntries(
+    Object.entries(query).filter(
+      ([, value]) => value !== undefined && value !== null && value !== ''
+    )
+  );
+
+  return Object.keys(cleaned).length ? cleaned : null;
+};
+
 /**
  * @typedef ApiResponse
  * @type {object}
@@ -33,14 +47,13 @@ const request = (options) =>
   new Promise((resolve, reject) => {
     const params = { ...defaultRequestParams, ...options };
     const parsedUrl = urlParse(options.url);
+    const query = cleanQuery(params.query);
 
     const req = https.request(
       {
         ...parsedUrl,
         method: params.method,
-        path: `${parsedUrl.path}${
-          !!params.query ? `?${queryStringify(params.query)}` : ''
-        }`,
+        path: `${parsedUrl.path}${!!query ? `?${queryStringify(query)}` : ''}`,
         headers: {
           Authorization: `OAuth ${options.token}`
         }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -7,7 +7,9 @@ const request = require('./request');
 const {
   API_RESOURCES_URL,
   API_COPY_URL,
-  API_MOVE_URL
+  API_MOVE_URL,
+  API_PUBLISH_URL,
+  API_UNPUBLISH_URL
 } = require('./constants');
 
 /**
@@ -83,9 +85,43 @@ const remove = async (token, path, permanently = false) =>
     }
   });
 
+/**
+ * Publish File or Folder
+ * @see https://yandex.com/dev/disk-api/doc/en/reference/publish
+ * @param {string} token OAuth token
+ * @param {string} path File or Folder Path
+ * @returns {Promise<Link, Error>} Promise to be resolved on publishing resource
+ */
+const publish = async (token, path) =>
+  (
+    await request.put({
+      url: API_PUBLISH_URL,
+      token,
+      query: { path }
+    })
+  ).data;
+
+/**
+ * Unpublish File or Folder
+ * @see https://yandex.com/dev/disk-api/doc/en/reference/publish#unpublish-q
+ * @param {string} token OAuth token
+ * @param {string} path File or Folder Path
+ * @returns {Promise<Link, Error>} Promise to be resolved on unpublishing resource
+ */
+const unpublish = async (token, path) =>
+  (
+    await request.put({
+      url: API_UNPUBLISH_URL,
+      token,
+      query: { path }
+    })
+  ).data;
+
 module.exports = {
   copy,
   create,
   move,
-  remove
+  remove,
+  publish,
+  unpublish
 };

--- a/lib/trash.js
+++ b/lib/trash.js
@@ -1,0 +1,46 @@
+/**
+ * Working with trash resources
+ * @module ya-disk/trash
+ */
+const request = require('./request');
+
+const { API_TRASH_URL, API_RESTORE_URL } = require('./constants');
+
+/**
+ * @typedef {import('./request').ApiResponse} ApiResponse
+ */
+
+/**
+ * Empty trash or delete a specific resource from trash
+ * @see https://yandex.com/dev/disk-api/doc/en/reference/trash-delete
+ * @param {string} token OAuth token
+ * @param {string} [path] Relative path to the resource in trash
+ * @returns {Promise<ApiResponse, Error>} Promise resolved with status and optional operation link
+ */
+const deleteResource = async (token, path) =>
+  await request.delete({
+    url: API_TRASH_URL,
+    token,
+    query: { path }
+  });
+
+/**
+ * Restore a resource from trash
+ * @see https://yandex.com/dev/disk-api/doc/en/reference/trash-restore
+ * @param {string} token OAuth token
+ * @param {string} path Relative path to the resource in trash
+ * @param {string} [name] New name for restored resource
+ * @param {boolean} [overwrite=false] Overwrite existing resource on restore
+ * @returns {Promise<ApiResponse, Error>} Promise resolved with status and link
+ */
+const restore = async (token, path, name, overwrite = false) =>
+  await request.put({
+    url: API_RESTORE_URL,
+    token,
+    query: { path, name, overwrite }
+  });
+
+module.exports = {
+  delete: deleteResource,
+  restore
+};

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -15,6 +15,9 @@ test('it should export all methods', () => {
   expect(typeof yaDisk.publicResources.saveToDisk).toBe('function');
   expect(typeof yaDisk.publicResources.list).toBe('function');
   expect(typeof yaDisk.recent).toBe('function');
+  expect(typeof yaDisk.trash).toBe('object');
+  expect(typeof yaDisk.trash.delete).toBe('function');
+  expect(typeof yaDisk.trash.restore).toBe('function');
   expect(typeof yaDisk.upload).toBe('object');
   expect(typeof yaDisk.upload.link).toBe('function');
   expect(typeof yaDisk.upload.remoteFile).toBe('function');

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -17,4 +17,6 @@ test('it should export all methods', () => {
   expect(typeof yaDisk.resources.remove).toBe('function');
   expect(typeof yaDisk.resources.copy).toBe('function');
   expect(typeof yaDisk.resources.move).toBe('function');
+  expect(typeof yaDisk.resources.publish).toBe('function');
+  expect(typeof yaDisk.resources.unpublish).toBe('function');
 });

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -9,6 +9,11 @@ test('it should export all methods', () => {
   expect(typeof yaDisk.meta.add).toBe('function');
   expect(typeof yaDisk.meta.get).toBe('function');
   expect(typeof yaDisk.operations).toBe('function');
+  expect(typeof yaDisk.publicResources).toBe('object');
+  expect(typeof yaDisk.publicResources.get).toBe('function');
+  expect(typeof yaDisk.publicResources.download).toBe('function');
+  expect(typeof yaDisk.publicResources.saveToDisk).toBe('function');
+  expect(typeof yaDisk.publicResources.list).toBe('function');
   expect(typeof yaDisk.recent).toBe('function');
   expect(typeof yaDisk.upload).toBe('object');
   expect(typeof yaDisk.upload.link).toBe('function');

--- a/tests/publicResource.spec.js
+++ b/tests/publicResource.spec.js
@@ -1,0 +1,167 @@
+const request = require('../lib/request');
+const publicResources = require('../lib/publicResource');
+
+const { API_TOKEN } = require('./constants');
+const {
+  API_PUBLIC_URL,
+  API_PUBLIC_RESOURCES_URL,
+  API_PUBLIC_DOWNLOAD_URL,
+  API_SAVE_TO_DISK_URL
+} = require('../lib/constants');
+
+const public_key = 'https://yadi.sk/d/AaaBbb1122Ccc';
+const path = '/foo/photo.png';
+const name = 'photo-renamed.png';
+
+const listOptions = {
+  limit: 10,
+  offset: 2,
+  type: 'file',
+  preview_size: '120x120'
+};
+
+jest.mock('../lib/request');
+
+describe('get', () => {
+  it('should call request.get and resolve Promise with data', () => {
+    const responseMock = {
+      data: {
+        public_key,
+        name: 'photo.png',
+        path: '/photo.png',
+        type: 'file'
+      },
+      status: 200
+    };
+    const getPromise = publicResources.get(API_TOKEN, public_key, { path });
+
+    expect(request.get).toHaveBeenCalledWith({
+      url: API_PUBLIC_RESOURCES_URL,
+      token: API_TOKEN,
+      query: { public_key, path }
+    });
+
+    request.get._resolve(responseMock);
+
+    expect(getPromise).resolves.toBe(responseMock.data);
+  });
+
+  it('should call request.get with default empty options', () => {
+    publicResources.get(API_TOKEN, public_key);
+
+    expect(request.get).toHaveBeenCalledWith({
+      url: API_PUBLIC_RESOURCES_URL,
+      token: API_TOKEN,
+      query: { public_key }
+    });
+  });
+});
+
+describe('download', () => {
+  it('should call request.get and resolve Promise with data', () => {
+    const responseMock = {
+      data: {
+        href: 'https://downloader.dst.yandex.ru/disk/...',
+        method: 'GET',
+        templated: false
+      },
+      status: 200
+    };
+    const downloadPromise = publicResources.download(
+      API_TOKEN,
+      public_key,
+      path
+    );
+
+    expect(request.get).toHaveBeenCalledWith({
+      url: API_PUBLIC_DOWNLOAD_URL,
+      token: API_TOKEN,
+      query: { public_key, path }
+    });
+
+    request.get._resolve(responseMock);
+
+    expect(downloadPromise).resolves.toBe(responseMock.data);
+  });
+
+  it('should omit path when not specified', () => {
+    publicResources.download(API_TOKEN, public_key);
+
+    expect(request.get).toHaveBeenCalledWith({
+      url: API_PUBLIC_DOWNLOAD_URL,
+      token: API_TOKEN,
+      query: { public_key, path: undefined }
+    });
+  });
+});
+
+describe('saveToDisk', () => {
+  it('should call request.post and resolve Promise with data', () => {
+    const responseMock = {
+      data: {
+        href: 'https://cloud-api.yandex.net/v1/disk/resources?path=disk%3A%2FDownloads%2Fphoto.png',
+        method: 'GET',
+        templated: false
+      },
+      status: 201
+    };
+    const savePromise = publicResources.saveToDisk(
+      API_TOKEN,
+      public_key,
+      path,
+      name
+    );
+
+    expect(request.post).toHaveBeenCalledWith({
+      url: API_SAVE_TO_DISK_URL,
+      token: API_TOKEN,
+      query: { public_key, path, name }
+    });
+
+    request.post._resolve(responseMock);
+
+    expect(savePromise).resolves.toBe(responseMock.data);
+  });
+
+  it('should omit optional params when not specified', () => {
+    publicResources.saveToDisk(API_TOKEN, public_key);
+
+    expect(request.post).toHaveBeenCalledWith({
+      url: API_SAVE_TO_DISK_URL,
+      token: API_TOKEN,
+      query: { public_key, path: undefined, name: undefined }
+    });
+  });
+});
+
+describe('list', () => {
+  it('should call request.get and resolve Promise with data', () => {
+    const responseMock = {
+      data: {
+        items: [
+          {
+            public_key,
+            name: 'photo.png',
+            path: 'disk:/foo/photo.png',
+            type: 'file'
+          }
+        ],
+        limit: 10,
+        offset: 2,
+        type: 'file'
+      },
+      status: 200
+    };
+    const listPromise = publicResources.list(API_TOKEN, listOptions);
+
+    expect(request.get).toHaveBeenCalledWith({
+      url: API_PUBLIC_URL,
+      token: API_TOKEN,
+      query: listOptions
+    });
+
+    request.get._resolve(responseMock);
+
+    expect(listPromise).resolves.toBe(responseMock.data);
+  });
+});

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -74,6 +74,56 @@ test('should call https.request with correct params', () => {
   );
 });
 
+test('should strip empty query params before calling https.request', () => {
+  request.request({
+    url,
+    token,
+    method,
+    query: {
+      foo: 'string',
+      bar: 3,
+      empty: '',
+      missing: undefined,
+      nil: null
+    }
+  });
+
+  expect(https.request).toHaveBeenCalledWith(
+    Object.assign({}, urlParsed, {
+      method,
+      path: `${urlParsed.path}?${queryString}`,
+      headers: {
+        Authorization: authHeader
+      }
+    }),
+    expect.any(Function)
+  );
+});
+
+test('should omit query string when all query params are empty', () => {
+  request.request({
+    url,
+    token,
+    method,
+    query: {
+      empty: '',
+      missing: undefined,
+      nil: null
+    }
+  });
+
+  expect(https.request).toHaveBeenCalledWith(
+    Object.assign({}, urlParsed, {
+      method,
+      path: urlParsed.path,
+      headers: {
+        Authorization: authHeader
+      }
+    }),
+    expect.any(Function)
+  );
+});
+
 test('should resolve Promise with parsed result and status code', (done) => {
   const expectedResponse = {
     param1: 4631577437,

--- a/tests/resources.spec.js
+++ b/tests/resources.spec.js
@@ -1,11 +1,20 @@
 const request = require('../lib/request');
-const { create, remove, copy, move } = require('../lib/resources');
+const {
+  create,
+  remove,
+  copy,
+  move,
+  publish,
+  unpublish
+} = require('../lib/resources');
 
 const { API_TOKEN } = require('./constants');
 const {
   API_RESOURCES_URL,
   API_COPY_URL,
-  API_MOVE_URL
+  API_MOVE_URL,
+  API_PUBLISH_URL,
+  API_UNPUBLISH_URL
 } = require('../lib/constants');
 
 const folderName = 'disk:/folderName';
@@ -176,5 +185,57 @@ describe('remove', () => {
       token: API_TOKEN,
       query: { path: folderName, permanently: false }
     });
+  });
+});
+
+describe('publish', () => {
+  it('should call request.put and resolve Promise with data', () => {
+    const responseMock = {
+      data: {
+        href: 'https://cloud-api.yandex.net/v1/disk/resources?path=disk%3A%2Ffoo%2Fbar',
+        method: 'GET',
+        templated: false
+      },
+      status: 200
+    };
+    const publishPromise = publish(API_TOKEN, folderName);
+
+    expect(request.put).toHaveBeenCalledWith({
+      url: API_PUBLISH_URL,
+      token: API_TOKEN,
+      query: {
+        path: folderName
+      }
+    });
+
+    request.put._resolve(responseMock);
+
+    expect(publishPromise).resolves.toBe(responseMock.data);
+  });
+});
+
+describe('unpublish', () => {
+  it('should call request.put and resolve Promise with data', () => {
+    const responseMock = {
+      data: {
+        href: 'https://cloud-api.yandex.net/v1/disk/resources?path=disk%3A%2Ffoo%2Fbar',
+        method: 'GET',
+        templated: false
+      },
+      status: 200
+    };
+    const unpublishPromise = unpublish(API_TOKEN, folderName);
+
+    expect(request.put).toHaveBeenCalledWith({
+      url: API_UNPUBLISH_URL,
+      token: API_TOKEN,
+      query: {
+        path: folderName
+      }
+    });
+
+    request.put._resolve(responseMock);
+
+    expect(unpublishPromise).resolves.toBe(responseMock.data);
   });
 });

--- a/tests/trash.spec.js
+++ b/tests/trash.spec.js
@@ -1,0 +1,79 @@
+const request = require('../lib/request');
+const trash = require('../lib/trash');
+
+const { API_TOKEN } = require('./constants');
+const { API_TRASH_URL, API_RESTORE_URL } = require('../lib/constants');
+
+const path = '/foo/photo.png';
+const name = 'photo-restored.png';
+const overwrite = true;
+
+jest.mock('../lib/request');
+
+describe('delete', () => {
+  it('should call request.delete with path and resolve Promise with data and status', () => {
+    const responseMock = {
+      data: {
+        href: 'https://cloud-api.yandex.net/v1/disk/operations?id=33ca7d03ab21ct41b4a40182e78d828a3f8b72cdb5f4c0e94cc4b1449a63a2fe',
+        method: 'GET',
+        templated: false
+      },
+      status: 202
+    };
+    const deletePromise = trash.delete(API_TOKEN, path);
+
+    expect(request.delete).toHaveBeenCalledWith({
+      url: API_TRASH_URL,
+      token: API_TOKEN,
+      query: { path }
+    });
+
+    request.delete._resolve(responseMock);
+
+    expect(deletePromise).resolves.toBe(responseMock);
+  });
+
+  it('should call request.delete without path to clear whole trash', () => {
+    trash.delete(API_TOKEN);
+
+    expect(request.delete).toHaveBeenCalledWith({
+      url: API_TRASH_URL,
+      token: API_TOKEN,
+      query: { path: undefined }
+    });
+  });
+});
+
+describe('restore', () => {
+  it('should call request.put and resolve Promise with data and status', () => {
+    const responseMock = {
+      data: {
+        href: 'https://cloud-api.yandex.net/v1/disk/resources?path=disk%3A%2Ffoo%2Fphoto-restored.png',
+        method: 'GET',
+        templated: false
+      },
+      status: 201
+    };
+    const restorePromise = trash.restore(API_TOKEN, path, name, overwrite);
+
+    expect(request.put).toHaveBeenCalledWith({
+      url: API_RESTORE_URL,
+      token: API_TOKEN,
+      query: { path, name, overwrite }
+    });
+
+    request.put._resolve(responseMock);
+
+    expect(restorePromise).resolves.toBe(responseMock);
+  });
+
+  it('should keep overwrite disabled by default', () => {
+    trash.restore(API_TOKEN, path);
+
+    expect(request.put).toHaveBeenCalledWith({
+      url: API_RESTORE_URL,
+      token: API_TOKEN,
+      query: { path, name: undefined, overwrite: false }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds support for Yandex Disk REST API methods that were previously missing from the library.

## What Changed
- Added resource publishing methods:
  - `resources.publish(token, path)`
  - `resources.unpublish(token, path)`
- Added new `publicResources` module:
  - `publicResources.get(token, public_key, options?)`
  - `publicResources.download(token, public_key, path?)`
  - `publicResources.saveToDisk(token, public_key, path?, name?)`
  - `publicResources.list(token, options?)`
- Added new `trash` module:
  - `trash.delete(token, path?)`
  - `trash.restore(token, path, name?, overwrite?)`
- Added endpoint constants required for public resources.
- Added request-level query sanitization for empty query values.
- Updated README with docs/examples for publish/unpublish and trash actions.
- Extended index exports to include new modules.

## Tests
- Added unit tests for `publicResources` and `trash` modules.
- Extended existing export and request tests.
- Full test suite passes on push (`12/12` suites, `44/44` tests).