### PR TITLE
fix: Publishing old version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,4 +35,4 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --tag old-version


### PR DESCRIPTION
Publishing v3.x w/ `old-version` tag