### PR TITLE
chore(node): drop Node 20 support in v4.x

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ "22", "24", "26" ]
+        node: [ "22", "24" ]
     name: Test with node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ "20", "22", "24" ]
+        node: [ "22", "24", "26" ]
     name: Test with node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["20", "22", "24"]
+        node: ["22", "24", "26"]
     name: Test with node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["22", "24", "26"]
+        node: ["22", "24"]
     name: Test with node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,12 @@
+.babelrc
 .eslintrc
+eslint.config.mjs
 .gitattributes
 .github
+.nyc_output
 .prettierrc
+.nvmrc
+.husky
 .vscode
 *.tgz
 coverage

--- a/README.md
+++ b/README.md
@@ -536,4 +536,4 @@ You may find examples of the real usage in the `examples` folder. You should obt
 API_TOKEN=[token] node examples/upload-remote-file.js
 ```
 
-Beware that examples work in nodejs >= 16.x.
+Beware that examples work in Node.js >= 22.x.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prettier": "3.8.1"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 22.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">= 20.0.0"
+    "node": ">= 22.0.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",


### PR DESCRIPTION
## Summary
This PR updates v4.x runtime support policy to drop Node 20 and move the baseline to Node 22+.

Closes #610

## Changes
- Updated `engines.node` in `package.json` to `>= 22.0.0`
- Updated CI matrices to test only Node `22` and `24` for now
- Updated README runtime note to Node.js >= 22.x
- Included `.npmignore` updates prepared during Step A

## Notes
- Non-LTS odd versions are not part of CI guarantees.
- Node 26 will be added to CI matrix once available in GitHub Actions runners.
