### PR TITLE
chore(node): drop Node 20 support on v3.x

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ "20", "22", "24" ]
+        node: [ "22", "24" ]
     name: Test with node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["20", "22", "24"]
+        node: ["22", "24"]
     name: Test with node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -412,4 +412,4 @@ You may find sample of the real usage in the example folder. You should obtain t
 API_TOKEN=[token] node examples/upload-remote-file.js
 ```
 
-Beware that examples work in nodejs >= 14.x.
+Beware that examples work in Node.js >= 22.x.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ya-disk",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -23,7 +23,7 @@
         "prettier": "3.8.1"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 22.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">= 20.0.0"
+    "node": ">= 22.0.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",


### PR DESCRIPTION
## Summary
Drop Node 20 support on `v3.x` and set the baseline to Node 22+.

## Changes
- Updated `engines.node` in `package.json` to `>= 22.0.0`
- Updated CI matrices in:
  - `.github/workflows/npm-test.yml`
  - `.github/workflows/npm-publish.yml`
  to test Node `22` and `24`
- Updated README runtime note to Node.js >= 22.x

## Notes
- Node 26 is intentionally not included yet due GitHub Actions availability.
