### PR TITLE
chore(#639): remove deprecated Husky v9 shebang lines from git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged -r --no-stash

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm test


### PR DESCRIPTION
Closes #639

Removes the deprecated Husky v8/v9 boilerplate from both hook files:

```sh
#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"
```

Husky warns these lines will fail in v10. Both `.husky/pre-commit` and `.husky/pre-push` now contain only the hook command itself.